### PR TITLE
refactor: set default lxc vlan_tag to numeric and null

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ module "single_lxc" {
   memory              = 1024
   memory_swap         = 1024
   user_ssh_key_public = "~/.ssh/id_ed25519.pub"
-  vlan_tag            = "1"
+  vlan_tag            = 1
   ipv4 = [
     {
       ipv4_address = "192.168.1.100/24"

--- a/examples/lxc/main.tf
+++ b/examples/lxc/main.tf
@@ -77,7 +77,7 @@ module "lxc_static_ip_config" {
   os_template         = "local:vztmpl/ubuntu-22.04-standard_22.04-1_amd64.tar.zst" # Required
   os_type             = "ubuntu"                                                   # Optional, recommended
   user_ssh_key_public = "~/.ssh/id_ed25519.pub"                                    # Optional, recommended
-  vlan_tag            = "1"                                                        # Optional, recommended
+  vlan_tag            = 1                                                          # Optional, recommended
   ipv4 = [
     {
       ipv4_address = "192.168.1.103/24"

--- a/modules/lxc/README.md
+++ b/modules/lxc/README.md
@@ -45,7 +45,7 @@
 | ------------ | ------- | ------------ | --------------------------------------------------------------------- | -------- |
 | vnic_name    | `eth0`  | String       | Networking adapter name                                               | no       |
 | vnic_bridge  | `vmbr0` | String       | Networking adapter bridge                                             | no       |
-| vlan_tag     | `1`     | String       | Network adapter VLAN tag                                              | no       |
+| vlan_tag     | `null`  | Number       | Network adapter VLAN tag                                              | no       |
 | ipv4         |         | List(Object) | Defaults to DHCP, see example below for setting static IP and Gateway | no       |
 | ipv4_address | `dhcp`  | String       | Defaults to DHCP, for static IPv4 address set CIDR                    | no       |
 | ipv4_gateway | `null`  | String       | Defaults to DHCP, for static IPv4 gateway set IP address              | no       |

--- a/modules/lxc/variables.tf
+++ b/modules/lxc/variables.tf
@@ -136,8 +136,8 @@ variable "vnic_bridge" {
 
 variable "vlan_tag" {
   description = "Networking adapter VLAN tag."
-  type        = string
-  default     = "1"
+  type        = number
+  default     = null
 }
 
 variable "ipv4" {

--- a/modules/vm-clone/README.md
+++ b/modules/vm-clone/README.md
@@ -51,7 +51,7 @@
 | disks                      | See Below         | List(Object) | See [disks variables](#disks-variables) below                                  | no       |
 | vnic_model                 | `virtio`          | String       | Networking adapter model, e.g. `virtio`                                        | no       |
 | vnic_bridge                | `vmbr0`           | String       | Networking adapter bridge, e.g. `vmbr0`                                        | no       |
-| vlan_tag                   | `null`               | Number       | Networking adapter VLAN tag                                                    | no       |
+| vlan_tag                   | `null`            | Number       | Networking adapter VLAN tag                                                    | no       |
 
 ### Disks Variables
 


### PR DESCRIPTION
Mirrors the update made to VM `vlan_tag` var in #6